### PR TITLE
Fix go.mod module path to match GitHub repository

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module hatena-blog-org
+module github.com/garaemon/hatena-blog-org
 
 go 1.18


### PR DESCRIPTION
## Summary
- Fixed the module path in go.mod from 'hatena-blog-org' to 'github.com/garaemon/hatena-blog-org'
- This resolves the 'go install' command failure due to module path mismatch

## Test plan
- [x] All existing tests pass
- [x] Module path now matches GitHub repository structure
- [x] Ready for 'go install github.com/garaemon/hatena-blog-org@latest' command

🤖 Generated with [Claude Code](https://claude.ai/code)