### PR TITLE
Add image upload support for Org-mode files

### DIFF
--- a/hatena_client_test.go
+++ b/hatena_client_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -163,5 +165,38 @@ More content.`
 	content := removeTitleFromMarkdown(markdown)
 	if content != markdown {
 		t.Error("Content should remain unchanged when no title is present")
+	}
+}
+
+func TestUploadImageFileNotFound(t *testing.T) {
+	client := NewHatenaClient("testuser", "testkey", "testdomain")
+	_, err := client.uploadImage("/nonexistent/image.jpg")
+	if err == nil {
+		t.Error("Expected error for nonexistent image file")
+	}
+	
+	if !strings.Contains(err.Error(), "failed to open image file") {
+		t.Errorf("Expected file open error, got: %v", err)
+	}
+}
+
+func TestUploadImageValidFile(t *testing.T) {
+	tmpFile := filepath.Join(os.TempDir(), "test_upload.jpg")
+	err := os.WriteFile(tmpFile, []byte("fake image content"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile)
+
+	client := NewHatenaClient("testuser", "testkey", "testdomain")
+	
+	_, err = client.uploadImage(tmpFile)
+	if err == nil {
+		t.Skip("Skipping actual upload test - would require real credentials and network access")
+	}
+
+	if !strings.Contains(err.Error(), "request failed") && 
+	   !strings.Contains(err.Error(), "image upload failed") {
+		t.Errorf("Expected network/API error, got: %v", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+
+type mockHatenaClient struct {
+	uploadedImages map[string]string
+	shouldError    bool
+}
+
+func (m *mockHatenaClient) uploadImage(imagePath string) (string, error) {
+	if m.shouldError {
+		return "", fmt.Errorf("mock upload error")
+	}
+	
+	if m.uploadedImages == nil {
+		m.uploadedImages = make(map[string]string)
+	}
+	
+	filename := filepath.Base(imagePath)
+	mockURL := "https://cdn.hatena.ne.jp/fotolife/user/" + filename
+	m.uploadedImages[imagePath] = mockURL
+	
+	return mockURL, nil
+}
+
+func TestProcessImageUploads(t *testing.T) {
+	tests := []struct {
+		name         string
+		markdown     string
+		imageLinks   []string
+		shouldError  bool
+		expectedMD   string
+		setupFiles   map[string]string
+	}{
+		{
+			name: "single image upload success",
+			markdown: `# Test Article
+
+Here is an image:
+![test.jpg](./test.jpg)
+
+End of article.`,
+			imageLinks: []string{"./test.jpg"},
+			shouldError: false,
+			expectedMD: `# Test Article
+
+Here is an image:
+![test.jpg](https://cdn.hatena.ne.jp/fotolife/user/test.jpg)
+
+End of article.`,
+			setupFiles: map[string]string{
+				"./test.jpg": "fake image content",
+			},
+		},
+		{
+			name: "multiple images upload success",
+			markdown: `# Test Article
+
+First image: ![img1.jpg](./img1.jpg)
+Second image: ![img2.png](./img2.png)
+
+End of article.`,
+			imageLinks: []string{"./img1.jpg", "./img2.png"},
+			shouldError: false,
+			expectedMD: `# Test Article
+
+First image: ![img1.jpg](https://cdn.hatena.ne.jp/fotolife/user/img1.jpg)
+Second image: ![img2.png](https://cdn.hatena.ne.jp/fotolife/user/img2.png)
+
+End of article.`,
+			setupFiles: map[string]string{
+				"./img1.jpg": "fake image 1",
+				"./img2.png": "fake image 2",
+			},
+		},
+		{
+			name: "no images",
+			markdown: `# Test Article
+
+No images here.
+
+End of article.`,
+			imageLinks: []string{},
+			shouldError: false,
+			expectedMD: `# Test Article
+
+No images here.
+
+End of article.`,
+			setupFiles: map[string]string{},
+		},
+		{
+			name: "image file not found",
+			markdown: `# Test Article
+
+Here is an image:
+![missing.jpg](./missing.jpg)
+
+End of article.`,
+			imageLinks: []string{"./missing.jpg"},
+			shouldError: false,
+			expectedMD: `# Test Article
+
+Here is an image:
+![missing.jpg](./missing.jpg)
+
+End of article.`,
+			setupFiles: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			originalDir, _ := os.Getwd()
+			defer os.Chdir(originalDir)
+			
+			err := os.Chdir(tmpDir)
+			if err != nil {
+				t.Fatalf("Failed to change directory: %v", err)
+			}
+
+			for filePath, content := range tt.setupFiles {
+				dir := filepath.Dir(filePath)
+				if dir != "." && dir != "/" {
+					err := os.MkdirAll(dir, 0755)
+					if err != nil {
+						t.Fatalf("Failed to create directory %s: %v", dir, err)
+					}
+				}
+				
+				err := os.WriteFile(filePath, []byte(content), 0644)
+				if err != nil {
+					t.Fatalf("Failed to create test file %s: %v", filePath, err)
+				}
+			}
+
+			mockClient := &mockHatenaClient{shouldError: tt.shouldError}
+			
+			result, err := processImageUploads(tt.markdown, tt.imageLinks, mockClient)
+			
+			if tt.shouldError && err == nil {
+				t.Error("Expected error but got none")
+				return
+			}
+			
+			if !tt.shouldError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expectedMD {
+				t.Errorf("Expected markdown:\n%q\nGot:\n%q", tt.expectedMD, result)
+			}
+		})
+	}
+}
+
+func TestProcessImageUploadsUploadError(t *testing.T) {
+	tmpDir := t.TempDir()
+	originalDir, _ := os.Getwd()
+	defer os.Chdir(originalDir)
+	
+	err := os.Chdir(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to change directory: %v", err)
+	}
+
+	err = os.WriteFile("test.jpg", []byte("fake image"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	markdown := "![test.jpg](./test.jpg)"
+	imageLinks := []string{"./test.jpg"}
+	
+	mockClient := &mockHatenaClient{shouldError: true}
+	
+	_, err = processImageUploads(markdown, imageLinks, mockClient)
+	if err == nil {
+		t.Error("Expected error for upload failure")
+	}
+
+	if !strings.Contains(err.Error(), "failed to upload image") {
+		t.Errorf("Expected upload error message, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add automatic image upload functionality for Org-mode files to Hatena Fotolife
- Detect and process image links in Org-mode format ([[file:path]] or [[./path]])
- Replace local image paths with uploaded URLs in generated Markdown
- Support for multiple image formats (jpg, jpeg, png, gif, bmp, webp, svg)

## Implementation Details
- **Image Detection**: extractImageLinks() function uses regex to find Org-mode image syntax
- **Upload API**: uploadImage() method implements Hatena Fotolife AtomPub API with WSSE auth
- **Processing Pipeline**: processImageUploads() coordinates the upload and URL replacement
- **Error Handling**: Comprehensive error handling with user feedback and warnings
- **Testability**: ImageUploader interface allows dependency injection for testing

## Test Coverage
- 34 total tests including 9 new comprehensive unit tests covering all scenarios
- Mock client implementation for isolated testing without network dependencies
- Error handling and edge case validation
- All existing functionality remains fully tested

🤖 Generated with [Claude Code](https://claude.ai/code)