### PR TITLE
Fix XML escaping and remove verbatim attributes, add debug option

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -18,14 +18,16 @@ func convertOrgToMarkdown(orgFilePath string) (string, error) {
 		return "", fmt.Errorf("file is not an org file: %s", orgFilePath)
 	}
 
-	cmd := exec.Command("pandoc", "-f", "org", "-t", "markdown", orgFilePath)
+	cmd := exec.Command("pandoc", "-f", "org", "-t", "markdown", "--wrap=preserve", orgFilePath)
 	output, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("pandoc conversion failed: %v", err)
 	}
 
 	markdown := string(output)
-	return filterOrgMetadata(markdown), nil
+	markdown = filterOrgMetadata(markdown)
+	markdown = removeVerbatimAttributes(markdown)
+	return markdown, nil
 }
 
 func filterOrgMetadata(markdown string) string {
@@ -48,6 +50,10 @@ func filterOrgMetadata(markdown string) string {
 	}
 
 	return strings.Join(filteredLines, "\n")
+}
+
+func removeVerbatimAttributes(markdown string) string {
+	return strings.ReplaceAll(markdown, "{.verbatim}", "")
 }
 
 func fileExists(filename string) bool {

--- a/converter_test.go
+++ b/converter_test.go
@@ -282,6 +282,44 @@ func TestFilterOrgMetadata(t *testing.T) {
 	}
 }
 
+func TestRemoveVerbatimAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single verbatim attribute",
+			input:    "Some text `code{.verbatim}` more text",
+			expected: "Some text `code` more text",
+		},
+		{
+			name:     "multiple verbatim attributes",
+			input:    "`first{.verbatim}` and `second{.verbatim}` code blocks",
+			expected: "`first` and `second` code blocks",
+		},
+		{
+			name:     "no verbatim attributes",
+			input:    "Regular text with `code` blocks",
+			expected: "Regular text with `code` blocks",
+		},
+		{
+			name:     "verbatim in code block",
+			input:    "```bash{.verbatim}\necho hello\n```",
+			expected: "```bash\necho hello\n```",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := removeVerbatimAttributes(tt.input)
+			if result != tt.expected {
+				t.Errorf("Expected:\n%q\nGot:\n%q", tt.expected, result)
+			}
+		})
+	}
+}
+
 func isPandocAvailable() bool {
 	_, err := exec.LookPath("pandoc")
 	return err == nil

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 		isDraft     = flag.Bool("draft", false, "Post as draft")
 		configFile  = flag.String("config", "", "Path to config file")
 		interactive = flag.Bool("interactive", false, "Interactive mode")
+		debug       = flag.Bool("debug", false, "Enable debug output")
 	)
 	flag.Parse()
 
@@ -43,7 +44,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	articleURL, err := postOrgFile(*orgFile, config, *category, *isDraft)
+	articleURL, err := postOrgFile(*orgFile, config, *category, *isDraft, *debug)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
@@ -90,7 +91,7 @@ func runInteractiveMode() {
 		os.Exit(1)
 	}
 
-	articleURL, err := postOrgFile(orgFile, config, category, isDraft)
+	articleURL, err := postOrgFile(orgFile, config, category, isDraft, false)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
@@ -99,7 +100,7 @@ func runInteractiveMode() {
 	fmt.Printf("Successfully posted to Hatena Blog!\nEdit URL: %s\n", articleURL)
 }
 
-func postOrgFile(orgFile string, config *Config, category string, isDraft bool) (string, error) {
+func postOrgFile(orgFile string, config *Config, category string, isDraft bool, debug bool) (string, error) {
 	absPath, err := getAbsPath(orgFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to get absolute path: %v", err)
@@ -134,7 +135,7 @@ func postOrgFile(orgFile string, config *Config, category string, isDraft bool) 
 		IsDraft:    isDraft,
 	}
 
-	return client.PostEntry(entry)
+	return client.PostEntry(entry, debug)
 }
 
 func validateConfig(config *Config) error {


### PR DESCRIPTION
## Summary
- Fix XML escaping for special characters (`<`, `>`, `&`, `"`) in title, content, and categories using `html.EscapeString()`
- Remove `{.verbatim}` attributes generated by pandoc during org to markdown conversion
- Add `--debug` flag to optionally display generated XML for debugging purposes

## Test plan
- [x] All existing tests pass
- [x] Added test cases for XML escaping with special characters
- [x] Added test cases for verbatim attribute removal
- [x] Added test case for debug mode functionality
- [x] Verified build succeeds without errors

🤖 Generated with [Claude Code](https://claude.ai/code)